### PR TITLE
python@3.8: two changes from upstream + style fix

### DIFF
--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -164,8 +164,6 @@ class PythonAT38 < Formula
     }.each do |unversioned_name, versioned_name|
       (libexec/"bin").install_symlink (bin/versioned_name).realpath => unversioned_name
     end
-
-
   end
 
   def post_install

--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -32,7 +32,8 @@ class PythonAT38 < Formula
   uses_from_macos "zlib"
 
   skip_clean "bin/pip3", "bin/pip-3.4", "bin/pip-3.5", "bin/pip-3.6", "bin/pip-3.7", "bin/pip-3.8"
-  skip_clean "bin/easy_install3", "bin/easy_install-3.4", "bin/easy_install-3.5", "bin/easy_install-3.6", "bin/easy_install-3.7", "bin/easy_install-3.8"
+  skip_clean "bin/easy_install3", "bin/easy_install-3.4", "bin/easy_install-3.5", "bin/easy_install-3.6",
+             "bin/easy_install-3.7", "bin/easy_install-3.8"
 
   resource "setuptools" do
     url "https://pypi.org/packages/source/s/setuptools/setuptools-46.0.0.zip"
@@ -282,10 +283,10 @@ class PythonAT38 < Formula
   end
 
   def caveats
-    if prefix.exist?
-      xy = (prefix/"Frameworks/Python.framework/Versions").children.min.basename.to_s
+    xy = if prefix.exist?
+      (prefix/"Frameworks/Python.framework/Versions").children.min.basename.to_s
     else
-      xy = version.to_s.slice(/(3\.\d)/) || "3.8"
+      version.to_s.slice(/(3\.\d)/) || "3.8"
     end
     <<~EOS
       Python has been installed as


### PR DESCRIPTION
- python: fix RuboCop Style/ConditionalAssignment.
- python: shorten long lines.

commits 4e254a9899ecec0791c03efb2ce9129426e08b63 and 7cc2f92e7633a504372c413b110ccfcfa7f50b2b