### PR TITLE
Cast added to force macos version to float (python 3.5)

### DIFF
--- a/Formula/python@3.5.rb
+++ b/Formula/python@3.5.rb
@@ -89,7 +89,7 @@ class PythonAT35 < Formula
       cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
     end
     # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
-    args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
+    args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version.to_f}"
 
     # We want our readline and openssl@1.1! This is just to outsmart the detection code,
     # superenv makes cc always find includes/libs!


### PR DESCRIPTION
Related PR #106 

I send you separate PR for fix each python version.
